### PR TITLE
Add proper configuration for release signing

### DIFF
--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,1 +1,3 @@
 /build
+release.properties
+release.keystore

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,6 +17,23 @@
 apply plugin: 'com.android.application'
 
 android {
+
+    File signingProperties = file('release.properties')
+
+    signingConfigs {
+        //noinspection GroovyMissingReturnStatement
+        release {
+            if (signingProperties.exists()) {
+                def Properties keyProps = new Properties()
+                keyProps.load(new FileInputStream(signingProperties))
+                storeFile file(keyProps["keystore"])
+                keyAlias keyProps["alias"]
+                storePassword keyProps["keystore.password"]
+                keyPassword keyProps["alias.password"]
+            }
+        }
+    }
+
     compileSdkVersion 25
     buildToolsVersion "25.0.3"
 
@@ -31,6 +48,12 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            zipAlignEnabled true
+            if (signingProperties.exists()) {
+                //noinspection GrUnresolvedAccess
+                //noinspection GroovyAssignabilityCheck
+                signingConfig signingConfigs.release
+            }
         }
     }
 }

--- a/sample/release.properties.sample
+++ b/sample/release.properties.sample
@@ -1,0 +1,9 @@
+## Sample release.properties file
+#
+# Copy this file to release.properties and fill the correct values
+#
+
+keystore=./release.keystore
+alias=org.sample.alias
+keystore.password=keystorepass
+alias.password=aliaspass


### PR DESCRIPTION
If you want that Google Play releases have a signature that you control and can use to push APK here, please send me a valid keystore and associated passwords / info (Beware of play store requirement for the certificate (duration, length, ...)

Else I'll use some private ones when times to push comes.